### PR TITLE
fix(ios): initial category with playandrecord

### DIFF
--- a/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
+++ b/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
@@ -712,7 +712,7 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
 - (void)initialize:(FlutterError *__autoreleasing *)error {
 #if TARGET_OS_IOS
   // Allow audio playback when the Ring/Silent switch is set to silent
-  [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
+  [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
 #endif
 
   [self.playersByTextureId

--- a/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
+++ b/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
@@ -823,11 +823,11 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
   // AVAudioSession doesn't exist on macOS, and audio always mixes, so just no-op.
 #else
   if (mixWithOthers) {
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord
                                      withOptions:AVAudioSessionCategoryOptionMixWithOthers
                                            error:nil];
   } else {
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
   }
 #endif
 }


### PR DESCRIPTION
為了解決bug 
錄製時，如果同時選video player & mic一起使用，category 貌似會被切成mediaplayback後，導致錄製失敗。
目前看log 是因為開啟video page 時，會把category設定成media playback，然後回recording page時，那次的錄製會有問題。
（是說不應該發生這件事情）
但我先把這邊會影響到audiosession setcategory 成 mediaplayback 先改成 set 成play and record 
這樣至少不會被設定成不能錄製的mediaplayback