### PR TITLE
feat(TF3R-4570): add option when audio session setCategory in initialize

### DIFF
--- a/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
+++ b/video_player_avfoundation/darwin/video_player_avfoundation/Sources/video_player_avfoundation/FVPVideoPlayerPlugin.m
@@ -712,7 +712,11 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
 - (void)initialize:(FlutterError *__autoreleasing *)error {
 #if TARGET_OS_IOS
   // Allow audio playback when the Ring/Silent switch is set to silent
-  [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
+  [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord
+                                   withOptions:AVAudioSessionCategoryOptionAllowBluetooth | 
+                                               AVAudioSessionCategoryOptionAllowBluetoothA2DP | 
+                                               AVAudioSessionCategoryOptionMixWithOthers
+                                         error:nil];
 #endif
 
   [self.playersByTextureId


### PR DESCRIPTION
* 之前的 [commit](https://github.com/XRSPACE-Inc/flutter_video_player/commit/df2f62f963b4bc0673f7d0a30a58ad299b2d05a6) 為了 reel recording 修改了 video player 在 initialize 時 audio session 的設定，但是 AVAudioSessionCategoryPlayAndRecord 預設使用 device 本身的揚聲器所以會斷開藍牙，因此加上 withOptions 設定保持連結。